### PR TITLE
re-add rspec task in rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,5 @@
 require "bundler/gem_tasks"
 
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+task :default => :spec


### PR DESCRIPTION
Rake task to run rspec has been removed from Rakefile in last commits.
I just add it back.