### PR TITLE
Travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - ruby-head
+  - 2.2
+  - 2.1
+  - 2.0.0
+  - 1.9.3
+branches:
+  only:
+    - travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
   - 1.9.3
 branches:
   only:
-    - travis
+    - master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fit
+# fit [![Build Status](https://travis-ci.org/tjwallace/fit.svg?branch=master)](https://travis-ci.org/tjwallace/fit)
 
 A ruby gem for parsing [fit files](http://www.thisisant.com/pages/products/fit-sdk). It makes heavy use of the [bindata gem](http://bindata.rubyforge.org/).
 
@@ -13,6 +13,14 @@ fit_file = Fit.load_file(ARGV[0])
 
 records = fit_file.records.select{ |r| r.content.record_type != :definition }.map{ |r| r.content }
 ```
+
+## Supported files
+
+This library has been tested with files coming from the following devices:
+  - Garmin Swim
+
+
+Please let me know if you have any success with files coming from devices that are not listed here.
 
 ## Contributing to fit
  


### PR DESCRIPTION
It provides integration with travis-ci.org.
All you need to do is connect travis-ci with tjwallace/fit repository and ensure that build is activated with following options:
  -  Build only if .travis.yml is present => ON
  - Build pushes => ON
  - Build pull requests => ON

I also take the opportunity to mention in the README the device I know is supported.
Do not hesitate to update it with others.