### PR TITLE
update dependencies version + fix issue due to fields being a reservedd word for bindata

### DIFF
--- a/fit.gemspec
+++ b/fit.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bindata", "~> 2.1.0"
-  spec.add_dependency "activesupport", "~> 4.2.0"
+  spec.add_dependency "bindata", "~> 2.4"
+  spec.add_dependency "activesupport", "~> 6.1"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.5.0"
+  spec.add_development_dependency "rspec", "~> 3.10"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "pry"

--- a/lib/fit/file/data.rb
+++ b/lib/fit/file/data.rb
@@ -19,7 +19,7 @@ module Fit
             end
           RUBY
 
-          definition.fields.each do |field|
+          definition.fit_fields.each do |field|
             code = ""
 
             # in case the field size is a multiple of the field length, we must build an array

--- a/lib/fit/file/definition.rb
+++ b/lib/fit/file/definition.rb
@@ -110,7 +110,7 @@ module Fit
         uint16be 1
       end
       bit8 :field_count
-      array :fields, :type => Field, :initial_length => :field_count
+      array :fit_fields, :type => Field, :initial_length => :field_count
 
       def endianness
         architecture.snapshot == 0 ? :little : :big

--- a/spec/file/definition_spec.rb
+++ b/spec/file/definition_spec.rb
@@ -10,16 +10,16 @@ describe Fit::File::Definition do
       its(:architecture) { should == 0 }
       its(:global_message_number) { should == 0 }
       its(:field_count) { should == 6 }
-      it { expect(subject.fields.size).to eq(subject.field_count) }
+      it { expect(subject.fit_fields.size).to eq(subject.field_count) }
 
       its(:record_type) { should == :definition }
       it 'returns the real type for fields' do
-        expect(subject.fields[0].real_type).to be == :uint32z
-        expect(subject.fields[1].real_type).to be == :date_time
-        expect(subject.fields[2].real_type).to be == :manufacturer
-        expect(subject.fields[3].real_type).to be == :uint16 # product
-        expect(subject.fields[4].real_type).to be == :uint16 # number
-        expect(subject.fields[5].real_type).to be == :file
+        expect(subject.fit_fields[0].real_type).to be == :uint32z
+        expect(subject.fit_fields[1].real_type).to be == :date_time
+        expect(subject.fit_fields[2].real_type).to be == :manufacturer
+        expect(subject.fit_fields[3].real_type).to be == :uint16 # product
+        expect(subject.fit_fields[4].real_type).to be == :uint16 # number
+        expect(subject.fit_fields[5].real_type).to be == :file
       end
     end
   end


### PR DESCRIPTION
When testing this lib with newest bindata, it appears that **fields** is now a reserved word, therefore I renamed it as fit_fields to avoid the error and everything seems to work fine.

I also updated the dependencies to match the latest versions.

Let me know if anything need to be modified for you to accept this PR.

@tjwallace, It might be good to publish a new version on rubygems.org with those fixes (let me know if you want me to update the version number with this PR)