### PR TITLE
add ability to set time offset with loading file + enhance spec for Local time

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ fit_file = Fit.load_file(ARGV[0])
 records = fit_file.records.select{ |r| r.content.record_type != :definition }.map{ |r| r.content }
 ```
 
+If some times returned for your file are around 1989 or 1990, then you need to get the offset and pass it to the `load_file` method
+This requires loading the file 2 times (1 to get the offset, and 1 to read the file with the offseted date)
+```ruby
+require 'fit'
+
+fit_file = Fit.load_file(ARGV[0])
+
+offset = nil
+records = fit_file.records.select { |r| r.content.record_type == :activity }.map(&:content)
+rec = records[0]
+local_ts = rec.send(:raw_timestamp).to_i
+offset = rec.send(:raw_local_timestamp).to_i if local_ts < 268435456
+
+
+fit_file = Fit.load_file(ARGV[0], offset)
+
+records = fit_file.records.select{ |r| r.content.record_type != :definition }.map{ |r| r.content }
+
+```
+
 ## Supported files
 
 This library has been tested with files coming from the following devices:

--- a/lib/fit.rb
+++ b/lib/fit.rb
@@ -17,7 +17,8 @@ require 'fit/file/definitions'
 require 'fit/version'
 
 module Fit
-  def self.load_file(path)
+  def self.load_file(path, time_offset = nil)
+    Fit::File::Types.time_offset = time_offset
     File.read ::File.open(path)
   end
 end

--- a/lib/fit/file/types.rb
+++ b/lib/fit/file/types.rb
@@ -4,6 +4,7 @@ module Fit
   class File
     module Types
       @@types = {}
+      @@time_offset = nil
 
       class << self
         def add_type(name, type, option = {})
@@ -16,10 +17,20 @@ module Fit
           nil
         end
 
+        def time_offset=(time_offset)
+          @@time_offset = time_offset
+        end
+
         def date_time_value(time, values, parameters)
           val = values.invert
           if time < val['min']
-            time.to_s
+            if @@time_offset
+              offsetted_time = @@time_offset + time
+              res = parameters[:utc] ? Time.utc(1989, 12, 31) + offsetted_time : Time.local(1989, 12, 31) + offsetted_time
+              res.to_s
+            else
+              time.to_s
+            end
           else
             res = parameters[:utc] ? Time.utc(1989, 12, 31) + time : Time.local(1989, 12, 31) + time
             res.to_s

--- a/spec/fit/file/types_spec.rb
+++ b/spec/fit/file/types_spec.rb
@@ -37,6 +37,12 @@ describe Fit::File::Types do
         expect(described_class.date_time_value(9999, { 268435456 => 'min' }, { utc: true })).to eql '9999'
         expect(described_class.date_time_value(9999, { 268435456 => 'min' }, { utc: false })).to eql '9999'
       end
+
+      it 'returns offsetted system time when offset is defined' do
+        described_class.time_offset = 788392680
+        expect(described_class.date_time_value(738748, { 268435456 => 'min' },
+                                               { utc: true })).to eql '2015-01-02 11:10:28 UTC'
+      end
     end
 
     context 'when value is above min' do
@@ -49,9 +55,8 @@ describe Fit::File::Types do
 
       context 'with local mode' do
         it 'returns exact date in locale time zone' do
-          # TODO: manage answer based on current system local
           expect(described_class.date_time_value(790509304, { 268435456 => 'min' },
-                                                 { utc: false })).not_to match(/UTC$/)
+                                                 { utc: false })).to match(/^2015-01-18 09:55:04 [+-]\d{4}$/)
         end
       end
     end


### PR DESCRIPTION
In the FIT File Types description, in FIT message `activity` we can find this description for `local_timestamp`
> Timestamp epoch expressed in local time. Used to determine the time_zone or convert timestamps to local time

I have not found a way to do that dynamically during loading, so I am proposing this PR.
It allows to load the file to get the offset and then use this offset as an input to load the file again (too bad the file has to be loaded twice).
I am using this trick for quite a while and it allows to get the proper time on file created before the garmin watch time is set properly with antfs-cli in my case.

Do not hesitate to let me know if anything need to be changed (this time I checked the `spec` and `rubocop` results are fine ;-) )

I also modified a test related to local time to make it timezone independant while checking the date itself.
I hope it will work with all time zones (not really tested)